### PR TITLE
Update karpenter.tf

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -76,7 +76,7 @@ resource "kubernetes_manifest" "karpenter_ec2_node_class" {
   count = var.karpenter_enabled ? 1 : 0
 
   manifest = {
-    "apiVersion" = "karpenter.k8s.aws/v1beta1"
+    "apiVersion" = "karpenter.k8s.aws/v1"
     "kind"       = "EC2NodeClass"
     "metadata" = {
       "name" = "default"


### PR DESCRIPTION
Updated the karpenter api to v1.
This should fix the:

`│ no matches for kind "EC2NodeClass" in group "karpenter.k8s.aws"`

# Code Checklist

Ensure the following tasks are completed.

- [ ] Is dependencies added with `poetry add`?
- [ ] Is the README.md updated?
- [ ] Are tests included?
  - [ ] Are the tests running?
- [ ] Are the names of the files correct?
- [ ] Add PR/Issue to opsZero Project and set to `Review` column

# Reviewer Checklist

- [ ] Go through https://docs.opszero.com/intro.html#pull-request-checklist

# Business Checklist

- [ ] Is the marketing landing page updated?
- [ ] Is the sales proposal updated?
- [ ] Is the documentation updated
