### PR TITLE
feat: Allow enabling the CloudWatch Observability Add-on for EKS

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -56,6 +56,7 @@ resource "aws_eks_addon" "core" {
     "aws-ebs-csi-driver",
     var.s3_csi_driver_enabled ? ["aws-mountpoint-s3-csi-driver"] : [],
     var.efs_enabled ? ["aws-efs-csi-driver"] : [],
+    var.cloudwatch_observability_enabled ? ["amazon-cloudwatch-observability"] : [],
   ]))
 
   cluster_name                = aws_eks_cluster.cluster.name

--- a/iam.tf
+++ b/iam.tf
@@ -425,3 +425,14 @@ resource "aws_iam_role_policy_attachment" "csi" {
   policy_arn = join("", aws_iam_policy.s3_policy.*.arn)
   role       = aws_iam_role.node.name
 }
+
+# Attach the AWS-managed CloudWatchAgentServerPolicy to the node IAM role.
+# We may want to harden this down a bit later, but it's essentially scoped
+# to a few read-only calls and the ability to write logs, metrics, and traces
+# to CloudWatch (metrics), CloudWatch Logs (logs), and X-Ray (traces).
+resource "aws_iam_role_policy_attachment" "cloudwatch_observability" {
+  count = var.cloudwatch_observability_enabled ? 1 : 0
+
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+  role       = aws_iam_role.node.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -461,3 +461,8 @@ variable "s3_csi_bucket_names" {
   default     = [""]
 }
 
+variable "cloudwatch_observability_enabled" {
+  description = "Enable or disable the CloudWatch Observability Add-on for EKS"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## Changes

- Adds a new `cloudwatch_observability_enabled` variable
- Conditionally installs the `amazon-cloudwatch-observability` add-on
- Conditionally attaches the AWS-managed CloudWatchAgentServerPolicy to the node role
