### PR TITLE
Revert "Bump terraform-aws-modules/eks/aws from 20.37.1 to 21.0.4"

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -6,7 +6,7 @@ module "karpenter" {
   count = var.karpenter_enabled ? 1 : 0
 
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "21.0.4"
+  version = "20.37.1"
 
   cluster_name = var.environment_name
 


### PR DESCRIPTION
Reverts opszero/terraform-aws-kubespot#476